### PR TITLE
feat: support multiple paths per transit

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -30,19 +30,21 @@ export interface TransitPath {
 export interface Station {
   id: string;
   label?: string,
-  labelPosition?: 'top' | 'top-right' | 'right' | 'bottom-right' | 'bottom' | 'bottom-left' | 'left' | 'top-left',
-  interchange?: boolean,
+  labelPosition?: 'top' | 'top-right' | 'right' | 'bottom-right' | 'bottom' | 'bottom-left' | 'left' | 'top-left';
+  interchange?: boolean;
   location: number;
   hidden?: boolean;
 }
 
 export interface TransitProps {
-  paths: TransitPath[],
-  stations?: Record<string, Station[]>,
+  paths: TransitPath[];
+  stations?: {
+    [pathId: string]: Station[];
+  },
   vehicles?: {
     pathId: string;
-    location: number,
-    direction: 'start' | 'end',
-  }[],
+    location: number;
+    direction: 'start' | 'end';
+  }[];
   color?: ColorDef,
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,15 +22,25 @@ export type LineDef = (StraightSegment | {
   mode: 'quadraticCurve',
 })[];
 
+export interface TransitPath {
+  id: string;
+  path: LineDef;
+}
+
+export interface Station {
+  id: string;
+  label?: string,
+  labelPosition?: 'top' | 'top-right' | 'right' | 'bottom-right' | 'bottom' | 'bottom-left' | 'left' | 'top-left',
+  interchange?: boolean,
+  location: number;
+  hidden?: boolean;
+}
+
 export interface TransitProps {
-  path: LineDef,
-  stations?: {
-    location: number,
-    label?: string,
-    labelPosition?: 'top' | 'top-right' | 'right' | 'bottom-right' | 'bottom' | 'bottom-left' | 'left' | 'top-left',
-    interchange?: boolean,
-  }[],
+  paths: TransitPath[],
+  stations?: Record<string, Station[]>,
   vehicles?: {
+    pathId: string;
     location: number,
     direction: 'start' | 'end',
   }[],


### PR DESCRIPTION
Support multiple paths for each transit line. To achieve this, each transit now has an array of `paths` each with a unique ID. Each transit station and vehicle must specify a pathId on which it lies - the position of the station/vehicle is relative to the path it lies on. 

Stations are specified in arrays indexed by the pathId. Vehicles now specify a `pathId` field.